### PR TITLE
Test revert from older commit

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -21,8 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
-define( 'PAYPLUG_GATEWAY_VERSION', '1.1.0.6' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.1.0.7' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -34,9 +33,7 @@ function init() {
 	if ( file_exists( plugin_dir_path( __FILE__ ) . '/vendor/autoload.php' ) ) {
 		require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
 	}
-
-	load_plugin_textdomain( 'payplug', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
-
+	PayplugWoocommerceHelper::load_plugin_textdomain( plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 	PayplugWoocommerce::get_instance();
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\init' );

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -490,4 +490,24 @@ class PayplugWoocommerceHelper {
             }
         }
     }
+
+	/**
+	 * Load translations from plugin languages folder.
+	 *
+	 * @param string $plugin_rel_path
+	 *
+	 * @return bool
+	 */
+	public static function load_plugin_textdomain( $plugin_rel_path ) {
+
+		$domain = 'payplug';
+
+		$locale = apply_filters( 'plugin_locale', is_admin() ? get_user_locale() : get_locale(), $domain );
+
+		$mofile = $domain . '-' . $locale . '.mo';
+
+		$path = WP_PLUGIN_DIR . '/' . trim( $plugin_rel_path, '/' );
+
+		return load_textdomain( $domain, $path . '/' . $mofile );
+	}
 }


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

