### PR TITLE
Release 1.2.2

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.2.0
+ * Version:         1.2.2
  * WC tested up to: 4.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.2.0' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.2.2' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: PayPlug
 Tags: payplug, woocommerce, gateway, payment, credit card, carte de crédit, carte bancaire, paiement, one click, paiement en ligne, oney
 Requires at least: 4.4
-Tested up to: 5.4
+Tested up to: 5.6
 Requires PHP: 5.6
-Stable tag: 1.2.0
+Stable tag: 1.2.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -80,6 +80,11 @@ PayPlug offers several plans to suit your needs and business requirements. **No 
 2. Display on a WordPress website
 
 == Changelog ==
+= 1.2.2 =
+* Tested up to Wordpress 5.6
+
+= 1.2.1 =
+* Rollback to Release 1.1.0
 
 = 1.2.0 =
 * Guaranteed installment payments by Oney


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

