### PR TITLE
[Wooc-165] : Ajout du contrôle getAccount dans le checkout

### DIFF
--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -45,7 +45,7 @@ class PayplugGatewayOney3x extends PayplugGateway
         add_action('woocommerce_order_item_add_action_buttons', [$this, 'oney_refund_text']);
 
         if (is_checkout()) {
-            $account = PayplugWoocommerceHelper::get_account_data_from_options();
+            $account = PayplugWoocommerceHelper::get_account_data_from_options(true);
             $oney_configuration = $account['configuration']['oney'];
             $this->min_oney_price = $oney_configuration['min_amounts']['EUR'] / 100;
             $this->max_oney_price = $oney_configuration['max_amounts']['EUR'] / 100;

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -19,9 +19,10 @@ if (!defined('ABSPATH')) {
  */
 class PayplugGatewayOney3x extends PayplugGateway
 {
+    const OPTION_NAME = "payplug_oney_config";
     const ONEY_UNAVAILABLE_CODE_COUNTRY_NOT_ALLOWED = 2;
     const ONEY_UNAVAILABLE_CODE_CART_SIZE_TOO_HIGH = 3;
-	const ONEY_PRODUCT_QUANTITY_MAXIMUM = 1000;
+    const ONEY_PRODUCT_QUANTITY_MAXIMUM = 1000;
 
     protected $oney_response;
     protected $min_oney_price;
@@ -43,14 +44,12 @@ class PayplugGatewayOney3x extends PayplugGateway
 
         add_action('woocommerce_order_item_add_action_buttons', [$this, 'oney_refund_text']);
 
-        try {
-            $http_response = Authentication::getAccount();
-            $oney_configuration = $http_response['httpResponse']['configuration']['oney'];
-            $this->min_oney_price = $oney_configuration['min_amounts']['EUR']/100;
-            $this->max_oney_price = $oney_configuration['max_amounts']['EUR']/100;
+        if (is_checkout()) {
+            $account = PayplugWoocommerceHelper::get_account_data_from_options();
+            $oney_configuration = $account['configuration']['oney'];
+            $this->min_oney_price = $oney_configuration['min_amounts']['EUR'] / 100;
+            $this->max_oney_price = $oney_configuration['max_amounts']['EUR'] / 100;
             $this->allowed_country_codes = $oney_configuration['allowed_countries'];
-        } catch ( \Payplug\Exception\UnauthorizedException $e ) {
-        } catch ( \Payplug\Exception\ConfigurationNotSetException $e ) {
         }
     }
 
@@ -107,7 +106,6 @@ HTML;
      */
     public function check_oney_is_available()
     {
-
         $cart = WC()->cart;
         $total_price = floatval($cart->total);
 		$products_qty = (int) $cart->cart_contents_count;
@@ -127,11 +125,12 @@ HTML;
         // Country check
         $country_code_shipping = WC()->customer->get_shipping_country();
         $country_code_billing = WC()->customer->get_billing_country();
+        
         if (!in_array($country_code_billing, $this->allowed_country_codes) || !in_array($country_code_shipping, $this->allowed_country_codes)) {
             $this->description = '<div class="payment_method_oney_x3_with_fees_disabled">'.__('Unavailable for the specified country.', 'payplug').'</div>';
             return self::ONEY_UNAVAILABLE_CODE_COUNTRY_NOT_ALLOWED;
         }
-
+        
         return true;
     }
 
@@ -319,6 +318,16 @@ HTML;
         if (!empty($description)) {
             echo wpautop(wptexturize($description));
         }
+    }
+
+    /**
+     * Build the key to retrieve the permissions.
+     *
+     * @return string
+     */
+    protected function get_key()
+    {
+        return self::OPTION_NAME . '_' . $this->mode;
     }
 
 }

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -452,7 +452,8 @@ class PayplugWoocommerceHelper {
         } else {
             try {
                 $parameters_account = Authentication::getAccount(new Payplug($options['mode'] === 'yes' ? $payplug_live_key : $payplug_test_key));
-                set_transient($transient_key, $account['httpResponse']);
+                set_transient($transient_key, $parameters_account['httpResponse']);
+                $account = get_transient($transient_key);
             } catch (\Payplug\Exception\UnauthorizedException $e) {
             } catch (\Payplug\Exception\ConfigurationNotSetException $e) {
             }

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -451,7 +451,7 @@ class PayplugWoocommerceHelper {
             $account = $payplug_oney_config;
         } else {
             try {
-                $account = Authentication::getAccount(new Payplug($options['mode'] === 'yes' ? $payplug_live_key : $payplug_test_key));
+                $parameters_account = Authentication::getAccount(new Payplug($options['mode'] === 'yes' ? $payplug_live_key : $payplug_test_key));
                 set_transient($transient_key, $account['httpResponse']);
             } catch (\Payplug\Exception\UnauthorizedException $e) {
             } catch (\Payplug\Exception\ConfigurationNotSetException $e) {


### PR DESCRIPTION
- Dans le constructeur du Gateway Oney 3x, on ne récupère les infos du compte que si on est sur le checkout.
- Ajout du paramètre force_update (défaut false) à la fonction get_account_data_from_options de PayplugWoocommerceHelper.

- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

