### PR TITLE
Affichage du détail de paiement pour Oney 3x et 4x

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.2.3.4
+ * Version:         1.2.3.4.5
  * WC tested up to: 5.1.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html

--- a/payplug.php
+++ b/payplug.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.2.3.4.5
+ * Version:         1.2.3.5
  * WC tested up to: 5.1.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html

--- a/src/Admin/Metabox.php
+++ b/src/Admin/Metabox.php
@@ -42,7 +42,8 @@ class Metabox {
 		}
 
 		$payment_method = PayplugWoocommerceHelper::is_pre_30() ? $order->payment_method : $order->get_payment_method();
-		if ( 'payplug' !== $payment_method ) {
+        
+		if ( 'payplug' !== $payment_method && 'oney_x3_with_fees' !== $payment_method && 'oney_x4_with_fees' !== $payment_method) {
 			return;
 		}
 


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

