### PR TITLE
Wooc 176

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.2.3.5
+ * Version:         1.2.3.7
  * WC tested up to: 5.1.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html

--- a/payplug.php
+++ b/payplug.php
@@ -20,7 +20,7 @@ namespace Payplug\PayplugWoocommerce;
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-define( 'PAYPLUG_GATEWAY_VERSION', '1.2.3.6' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.2.3.7' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

