### PR TITLE
Hotfix wooc194 wooc223

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.2.8' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.2.8.1' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -206,7 +206,7 @@ HTML;
                     'merchant_item_id' => 'cart-'.$data['id'].'-'.$data['product_id'],
                     'name' => $data['name'],
                     'expected_delivery_date' => date('Y-m-d'),
-                    'total_amount' => $total,
+                    'total_amount' => (int) $total,
                     'price' =>  round($total / $data['quantity']),
                     'quantity' =>  $data['quantity']
                 ];

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -472,8 +472,8 @@ class PayplugWoocommerceHelper {
             } catch (\Payplug\Exception\ConfigurationNotSetException $e) {
             }
         }
-        $account['oneyEnabled'] = $options['oney'] ? $options['oney'] : '';
-        $account['oneyCgvEnabled'] = $options['oneycgv'] ? $options['oneycgv'] : '';
+        $account['oneyEnabled'] = (!isset($options['oney']) && !empty($options['oney'])) ? $options['oney'] : '';
+        $account['oneyCgvEnabled'] = (!isset($options['oneycgv']) && !empty($options['oneycgv'])) ? $options['oneycgv'] : '';
         return $account;
 
 	}


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

