### PR TITLE
WOOC-224, WOOC-232, Adding a check if the multiple transaction to ign…

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.2.9' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.2.9.2' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/src/Gateway/PayplugResponse.php
+++ b/src/Gateway/PayplugResponse.php
@@ -64,10 +64,14 @@ class PayplugResponse {
 		$metadata = PayplugWoocommerceHelper::extract_transaction_metadata( $resource );
 		$order_metadata = $order->get_meta('_payplug_metadata', true);
 
-		if (is_array($order_metadata) && array_key_exists('transaction_in_progress', $order_metadata)) {
-			PayplugGateway::log(sprintf('Order #%s : Order Oney IPN already in progress. Ignoring IPN', $order_id));
-			return;
-		}
+        if ( isset( $resource->payment_method ) && is_array( $resource->payment_method ) ) {
+            if ( in_array( $resource->payment_method['type'], array( 'oney_x3_with_fees', 'oney_x4_with_fees' ) ) ) {
+                if ( is_array( $order_metadata ) && array_key_exists( 'transaction_in_progress', $order_metadata ) ) {
+                    PayplugGateway::log( sprintf( 'Order #%s : Order Oney IPN already in progress. Ignoring IPN', $order_id ) );
+                    return;
+                }
+            }
+        }
 
 		if ( $resource->is_paid ) {
 			PayplugWoocommerceHelper::set_flag_ipn_order($order, $metadata, true);


### PR DESCRIPTION
…ore come from an Oney Payment

- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs
- [x] Order in error (waiting 15m in paymant form) become "paid" when paid
- [x] Standard payment doesn't ignore the multiple transaction call for Oney
- [x] Oney payment check if there is multiple transaction to ignore

