### PR TITLE
WOOC-239 : Correction retour paiement refusé oney

### DIFF
--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -183,7 +183,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
         }
 
         $order = wc_get_order($order_id); 
-        if (!$order instanceof \WC_Order) {
+        if (!in_array($payment_method, ['payplug', 'oney_x3_with_fees', 'oney_x4_with_fees'])) {
             return;
         }
 


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

