### PR TITLE
WOOC-251 : Display full details and no tooltip for title and descript…

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.2.11.3' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.2.11.4' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -282,14 +282,14 @@ class PayplugGateway extends WC_Payment_Gateway_CC
                 'type'        => 'text',
                 'description' => __('The payment solution title displayed during checkout.', 'payplug'),
                 'default'     => _x('Credit card checkout', 'Default gateway title', 'payplug'),
-                'desc_tip'    => true,
+                'desc_tip'    => false,
             ],
             'description'             => [
                 'title'       => __('Description', 'payplug'),
                 'type'        => 'text',
                 'description' => __('The payment solution description displayed during checkout.', 'payplug'),
                 'default'     => '',
-                'desc_tip'    => true,
+                'desc_tip'    => false,
             ],
             'title_connexion'         => [
                 'title' => __('Connection', 'payplug'),


### PR DESCRIPTION

- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

