### PR TITLE
WOOC-195 - resolving warning on wp-admin

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.3.0.2' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.3.0.3' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -729,10 +729,10 @@ class PayplugGateway extends WC_Payment_Gateway_CC
                         $val = 'no';
                         break;
                     case 'payplug_test_key':
-                        $val = esc_attr($response['test']);
+                        $val = !empty($response['test']) ? esc_attr($response['test']) : null;
                         break;
                     case 'payplug_live_key':
-                        $val = esc_attr($response['live']);
+                        $val = !empty($response['live']) ? esc_attr($response['live']) : null;
                         break;
                     case 'payplug_merchant_id':
                         $val = esc_attr($merchant_id);
@@ -1483,7 +1483,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
      */
     public function check_gateway($gateways)
     {
-        if (isset($gateways[$this->id]) && $gateways[$this->id]->id == $this->id) {
+        if ( !empty( WC()->cart ) && isset($gateways[$this->id]) && $gateways[$this->id]->id == $this->id) {
             $order_amount = $this->get_order_total();
             if ($order_amount < self::MIN_AMOUNT || $order_amount > self::MAX_AMOUNT) {
                 unset($gateways[$this->id]);


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

