### PR TITLE
WOOC-273 support backoffice orders

### DIFF
--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -131,6 +131,10 @@ HTML;
 		if( !empty(get_query_var('order-pay')) ){
 			$order = wc_get_order(get_query_var('order-pay'));
 			$items = $order->get_items();
+
+			$country_code_shipping = $order->get_shipping_country();
+			$country_code_billing = $order->get_billing_country();
+
 			$this->order_items_to_cart($cart, $items);
 		}
 
@@ -150,17 +154,19 @@ HTML;
         }
 
         // Country check
-        $country_code_shipping = WC()->customer->get_shipping_country();
-        $country_code_billing = WC()->customer->get_billing_country();
+		if( empty($country_code_shipping) || empty($country_code_shipping) ){
+			$country_code_shipping = WC()->customer->get_shipping_country();
+			$country_code_billing = WC()->customer->get_billing_country();
+		}
 
-        if ( !$this->validate_shipping_billing_country() ||
+        if ( !$this->validate_shipping_billing_country($country_code_shipping, $country_code_billing) ||
 			!$this->allowed_country($country_code_billing, $this->allowed_country_codes) ||
 			!$this->allowed_country($country_code_shipping, $this->allowed_country_codes)
 		) {
             $this->description = '<div class="payment_method_oney_x3_with_fees_disabled">'.__('Unavailable for the specified country.', 'payplug').'</div>';
             return self::ONEY_UNAVAILABLE_CODE_COUNTRY_NOT_ALLOWED;
         }
-        
+
         return true;
     }
 
@@ -377,12 +383,8 @@ HTML;
 	 * @return bool
 	 *
 	 */
-	public function validate_shipping_billing_country(): Bool
+	public function validate_shipping_billing_country($shipping_country, $billing_country): Bool
 	{
-
-		$billing_country    = WC()->customer->get_billing_country();
-		$shipping_country  = WC()->customer->get_shipping_country();
-
 		if($billing_country === $shipping_country)
 			return true;
 


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

