### PR TITLE
remove return type declarations to support php5.*

### DIFF
--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -383,7 +383,7 @@ HTML;
 	 * @return bool
 	 *
 	 */
-	public function validate_shipping_billing_country($shipping_country, $billing_country): Bool
+	public function validate_shipping_billing_country($shipping_country, $billing_country)
 	{
 		if($billing_country === $shipping_country)
 			return true;
@@ -398,7 +398,7 @@ HTML;
 	 * @param array $allowed
 	 * @return bool
 	 */
-	public function allowed_country(string $country, array $allowed): Bool
+	public function allowed_country(string $country, array $allowed)
 	{
 		if( in_array($country, $allowed))
 			return true;

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -543,7 +543,7 @@ class PayplugWoocommerceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function show_oney_popup() : bool
+	public static function show_oney_popup()
 	{
 		preg_match( '([a-z-]+)', get_locale(), $country );
 		$country = strtoupper($country[0]);


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

