### PR TITLE
WOOC-272

### DIFF
--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -1024,6 +1024,11 @@ class PayplugGateway extends WC_Payment_Gateway_CC
     {
         PayplugGateway::log(sprintf('Processing refund for order #%s', $order_id));
 
+		if( !$this->user_logged_in()){
+			PayplugGateway::log(__('You must be logged in with your PayPlug account.', 'payplug'), 'error');
+			return new \WP_Error('process_refund_error', __('You must be logged in with your PayPlug account.', 'payplug'));
+		}
+
         $order = wc_get_order($order_id);
         if (!$order instanceof \WC_Order) {
             PayplugGateway::log(sprintf('The order #%s does not exist.', $order_id), 'error');


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

