### PR TITLE
Fix pending oney payments

### DIFF
--- a/src/Gateway/PayplugResponse.php
+++ b/src/Gateway/PayplugResponse.php
@@ -198,18 +198,17 @@ class PayplugResponse {
 
 			return;
 		}
-		if ( ( $resource->is_paid == true ) && ( $resource->failure == null ) ) {
-			$log = new \WC_Logger();
-			$log->log( 'INFO', sprintf( 'Order #%s : Oney payment SUCCESS', $order_id ) );
-		}
-		if ( ( $resource->is_paid == false ) && ( $resource->failure != null ) ) {
-			$log = new \WC_Logger();
-			$log->log( 'INFO', sprintf( 'Order #%s : Oney payment FAILED', $order_id ) );
-		}
-		if ( ( $resource->is_paid == false ) && ( $resource->failure == null ) && ( $resource->is_pending == true ) ) {
-			$log = new \WC_Logger();
-			$log->log( 'INFO', sprintf( 'Order #%s : Oney payment PENDING and checked by an Oney agent', $order_id ) );
 
+		if ( ( $resource->is_paid == true ) && ( $resource->failure == null ) ) {
+			PayplugGateway::log( sprintf( 'Order #%s : Oney payment SUCCESS', $order_id ) );
+		}
+
+		if ( ( $resource->is_paid == false ) && ( $resource->failure != null ) ) {
+			PayplugGateway::log( sprintf( 'Order #%s : Oney payment FAILED', $order_id ) );
+		}
+
+		if ( ( $resource->is_paid == false ) && ( $resource->failure == null ) && ( $resource->payment_method['is_pending'] == true ) ) {
+			PayplugGateway::log( sprintf( 'Order #%s : Oney payment PENDING and checked by an Oney agent', $order_id ) );
 		}
 	}
 


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

