### PR TITLE
Oney threshold front check

### DIFF
--- a/src/Front/PayplugOney.php
+++ b/src/Front/PayplugOney.php
@@ -30,9 +30,9 @@ class PayplugOney
 	 */
 	public function handleMinMaxAmount()
 	{
-		$oney_range = PayplugWoocommerceHelper::get_min_max_oney();
-		$this->set_max_amount($oney_range['max']);
-		$this->set_min_amount($oney_range['min']);
+		$thresholds = PayplugWoocommerceHelper::get_local_oney_threshold();
+		$this->set_max_amount($thresholds['oney_thresholds_max']);
+		$this->set_min_amount($thresholds['oney_thresholds_min']);
 	}
 
 	public function handleOneySimulation()

--- a/src/Front/PayplugPayWithOney.php
+++ b/src/Front/PayplugPayWithOney.php
@@ -15,9 +15,10 @@ class PayplugPayWithOney extends PayplugOney
 	 */
 	public function check_oney_frontend() {
 
-		if ( ( is_cart() || is_checkout()) && PayplugWoocommerceHelper::is_oney_available() ) {
+		if ( ( is_cart() || is_checkout()) && PayplugWoocommerceHelper::is_oney_available()) {
 
 			add_action('woocommerce_cart_totals_after_order_total', [$this, 'oney_simulate_payment_detail']);
+		//	add_action('woocommerce_review_order_before_payment', [$this, 'oney_simulate_payment_detail']);
 
 			add_action( 'wp_enqueue_scripts', [$this, 'add_oney_css'] );
 

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -93,10 +93,10 @@ class PayplugGateway extends WC_Payment_Gateway_CC
             : self::$log->log($level, $message, array('source' => 'payplug_gateway'));
     }
 
-    /** 
+    /**
      * Construct method
      *
-     * @return void 
+     * @return void
      */
     public function __construct()
     {
@@ -1179,8 +1179,8 @@ class PayplugGateway extends WC_Payment_Gateway_CC
     public function validate_order_amount($amount)
     {
         if (
-            $amount < PayplugWoocommerceHelper::get_minimum_amount()
-            || $amount > PayplugWoocommerceHelper::get_maximum_amount()
+            $amount < $this->oney_thresholds_min
+            || $amount > $this->oney_thresholds_max
         ) {
             return new \WP_Error(
                 'invalid order amount',

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -50,8 +50,9 @@ class PayplugGatewayOney3x extends PayplugGateway
 
         self::set_oney_configuration();
 
-		$this->min_oney_price = PayplugWoocommerceHelper::get_local_oney_threshold()['oney_thresholds_min'];
-		$this->max_oney_price = PayplugWoocommerceHelper::get_local_oney_threshold()['oney_thresholds_max'];
+		/*$this->min_oney_price = PayplugWoocommerceHelper::get_local_oney_threshold()['oney_thresholds_min'];
+		$this->max_oney_price = PayplugWoocommerceHelper::get_local_oney_threshold()['oney_thresholds_max'];*/
+
     }
 
     /**
@@ -144,8 +145,8 @@ HTML;
 		$products_qty = (int) $cart->cart_contents_count;
 
 		// Min and max
-        if ($total_price < $this->min_oney_price || $total_price > $this->max_oney_price) {
-            $this->description = '<div class="payment_method_oney_x3_with_fees_disabled">'.sprintf(__('The total amount of your order should be between %s€ and %s€ to pay with Oney.', 'payplug'), $this->min_oney_price, $this->max_oney_price).'</div>';
+        if ($total_price < $this->oney_thresholds_min || $total_price > $this->oney_thresholds_max) {
+            $this->description = '<div class="payment_method_oney_x3_with_fees_disabled">'.sprintf(__('The total amount of your order should be between %s€ and %s€ to pay with Oney.', 'payplug'), $this->oney_thresholds_min , $this->oney_thresholds_max ).'</div>';
             return false;
         }
 

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -49,6 +49,9 @@ class PayplugGatewayOney3x extends PayplugGateway
         }
 
         self::set_oney_configuration();
+
+		$this->min_oney_price = PayplugWoocommerceHelper::get_local_oney_threshold()['oney_thresholds_min'];
+		$this->max_oney_price = PayplugWoocommerceHelper::get_local_oney_threshold()['oney_thresholds_max'];
     }
 
     /**

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -342,7 +342,13 @@ class PayplugWoocommerceHelper {
 	 * @return int
 	 */
 	public static function get_minimum_amount() {
-		return 99;
+		$min = self::get_local_oney_threshold()['oney_thresholds_min'];
+		if ($min) {
+			return $min;
+		} else {
+			return 99;
+		}
+
 	}
 
 	/**
@@ -353,7 +359,13 @@ class PayplugWoocommerceHelper {
 	 * @return int
 	 */
 	public static function get_maximum_amount() {
-		return 2000000;
+		$max = self::get_local_oney_threshold()['oney_thresholds_max'];
+		if ($max) {
+			return $max;
+		} else {
+			return 2000000;
+		}
+
 	}
 
 	/**
@@ -486,6 +498,21 @@ class PayplugWoocommerceHelper {
 	}
 
 	/**
+	 *
+	 * Retrienve the local oney threshold configration
+	 *
+	 * @return array
+	 */
+
+	public static function get_local_oney_threshold() {
+		$options = get_option('woocommerce_payplug_settings', []);
+		return [
+			'oney_thresholds_min' => $options['oney_thresholds_min'],
+			'oney_thresholds_max' => $options['oney_thresholds_max']
+		];
+	}
+
+	/**
 	 * Set current option from payplug settings and api call
 	 *
 	 * @return void
@@ -593,6 +620,14 @@ class PayplugWoocommerceHelper {
 	{
 		preg_match( '([a-z-]+)', get_locale(), $country );
 		return strtoupper($country[0]);
+	}
+
+	public static function amount_check($amount) {
+		if ($amount < self::get_minimum_amount() || $amount > self::get_maximum_amount()) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 
 }

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -334,39 +334,7 @@ class PayplugWoocommerceHelper {
 		return ( self::is_country_supported( $country ) ) ? strtoupper( $country ) : 'FR';
 	}
 
-	/**
-	 * Get minimum amount allowed by PayPlug.
-	 *
-	 * This amount is in cents.
-	 *
-	 * @return int
-	 */
-	public static function get_minimum_amount() {
-		$min = self::get_local_oney_threshold()['oney_thresholds_min'];
-		if ($min) {
-			return $min;
-		} else {
-			return 99;
-		}
 
-	}
-
-	/**
-	 * Get maximum amount allowed by PayPlug.
-	 *
-	 * This amount is in cents.
-	 *
-	 * @return int
-	 */
-	public static function get_maximum_amount() {
-		$max = self::get_local_oney_threshold()['oney_thresholds_max'];
-		if ($max) {
-			return $max;
-		} else {
-			return 2000000;
-		}
-
-	}
 
 	/**
 	 * Convert amount in cents.
@@ -499,7 +467,7 @@ class PayplugWoocommerceHelper {
 
 	/**
 	 *
-	 * Retrienve the local oney threshold configration
+	 * Retrieve the local oney threshold configration
 	 *
 	 * @return array
 	 */
@@ -620,14 +588,6 @@ class PayplugWoocommerceHelper {
 	{
 		preg_match( '([a-z-]+)', get_locale(), $country );
 		return strtoupper($country[0]);
-	}
-
-	public static function amount_check($amount) {
-		if ($amount < self::get_minimum_amount() || $amount > self::get_maximum_amount()) {
-			return false;
-		} else {
-			return true;
-		}
 	}
 
 }


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

