### PR TITLE
Fix oney thresholds

### DIFF
--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -1186,15 +1186,18 @@ class PayplugGateway extends WC_Payment_Gateway_CC
      */
     public function validate_order_amount($amount)
     {
-        if (
-            $amount < $this->oney_thresholds_min
-            || $amount > $this->oney_thresholds_max
-        ) {
-            return new \WP_Error(
-                'invalid order amount',
-                sprintf(__('Payments for this amount (%s) are not authorised with this payment gateway.', 'payplug'), \wc_price($amount / 100))
-            );
-        }
+		if ($this->id != "payplug") {
+			if (
+				$amount < $this->oney_thresholds_min
+				|| $amount > $this->oney_thresholds_max
+			) {
+				return new \WP_Error(
+					'invalid order amount',
+					sprintf(__('Payments for this amount (%s) are not authorised with this payment gateway.', 'payplug'), \wc_price($amount / 100))
+				);
+			}
+		}
+
 
         return $amount;
     }

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -1186,18 +1186,15 @@ class PayplugGateway extends WC_Payment_Gateway_CC
      */
     public function validate_order_amount($amount)
     {
-		if ($this->id != "payplug") {
-			if (
-				$amount < $this->oney_thresholds_min
-				|| $amount > $this->oney_thresholds_max
-			) {
-				return new \WP_Error(
-					'invalid order amount',
-					sprintf(__('Payments for this amount (%s) are not authorised with this payment gateway.', 'payplug'), \wc_price($amount / 100))
-				);
-			}
-		}
-
+        if (
+            $amount < PayplugWoocommerceHelper::get_minimum_amount()
+            || $amount > PayplugWoocommerceHelper::get_maximum_amount()
+        ) {
+            return new \WP_Error(
+                'invalid order amount',
+                sprintf(__('Payments for this amount (%s) are not authorised with this payment gateway.', 'payplug'), \wc_price($amount / 100))
+            );
+        }
 
         return $amount;
     }


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

