### PR TITLE
WOOC-350 fail safe & fix inactive accounts problem

### DIFF
--- a/src/PayplugWoocommerce.php
+++ b/src/PayplugWoocommerce.php
@@ -152,7 +152,7 @@ class PayplugWoocommerce {
 		$options = get_option('woocommerce_payplug_settings', []);
 
 		//if live and don't have country setted on the option
-		if (isset($options['payplug_live_key']) && !isset($options['payplug_merchant_country'])) {
+		if ( !isset($options['payplug_merchant_country']) ) {
 			$options['payplug_merchant_country'] = PayplugWoocommerceHelper::UpdateCountryOption($options);
 
 		}else if( isset($options['payplug_test_key']) && !isset($options['payplug_merchant_country']) ){

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -642,7 +642,14 @@ class PayplugWoocommerceHelper {
 	public static function UpdateCountryOption($options){
 
 		try {
-			$response = Authentication::getAccount(new Payplug($options['payplug_live_key']));
+
+			//fail safe for non activated account
+			$key = $options['mode'] === "yes" && !empty($options['payplug_live_key']) ? $options['payplug_live_key'] : $options['payplug_test_key'];
+			if( empty($options['payplug_live_key'] )){
+				$options['mode'] = "no";
+			}
+
+			$response = Authentication::getAccount(new Payplug($key));
 
 			if (isset($response['httpResponse']['country'])) {
 				$options['payplug_merchant_country'] = $response['httpResponse']['country'];


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

