### PR TITLE
WOOC-348

### DIFF
--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -427,8 +427,8 @@ class PayplugGateway extends WC_Payment_Gateway_CC
 	        'oney_thresholds'     => [
 		        'title'       => '',
 		        'type'        => 'oney_thresholds',
-		        'description' => sprintf(__('I would like to offer guaranteed payment in installments for amounts between %s and %s.', 'payplug'),
-                    '<b class="min">' . $this->oney_thresholds_min . '€</b>', '<b class="max">' . $this->oney_thresholds_max . '€</b>'),
+		        'description' => sprintf(__('I would like to offer guaranteed payment in installments for amounts between %s€ and %s€.', 'payplug'),
+                    '<b class="min">' . $this->oney_thresholds_min . '</b>', '<b class="max">' . $this->oney_thresholds_max . '</b>'),
 		        'desc_tip'    => false
 	        ],
 	        'oney_thresholds_min' => [


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

