### PR TITLE
WOOC-356

### DIFF
--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -1445,7 +1445,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
                     <input type="hidden" name="save" value="logout">
                     <?php wp_nonce_field('payplug_user_logout', '_logoutaction'); ?>
                     |
-                    <a href="https://portal-qa.payplug.com" target="_blank"><?php _e('Go to your PayPlug Portal', 'payplug'); ?></a>
+                    <a href="https://portal.payplug.com" target="_blank"><?php _e('Go to your PayPlug Portal', 'payplug'); ?></a>
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

