### PR TITLE
WOOC-341

### DIFF
--- a/src/Controller/Bancontact.php
+++ b/src/Controller/Bancontact.php
@@ -2,10 +2,11 @@
 
 namespace Payplug\PayplugWoocommerce\Controller;
 
-use Payplug\PayplugWoocommerce\Gateway\PayplugGatewayRequirements;
-use Payplug\PayplugWoocommerce\Gateway\PayplugPermissions;
+use Payplug\Exception\HttpException;
+use Payplug\PayplugWoocommerce\Gateway\PayplugAddressData;
 use Payplug\PayplugWoocommerce\PayplugWoocommerceHelper;
 use Payplug\PayplugWoocommerce\Gateway\PayplugGateway;
+use Payplug\Resource\Payment as PaymentResource;
 
 class Bancontact extends PayplugGateway
 {
@@ -55,6 +56,92 @@ class Bancontact extends PayplugGateway
 			$icons_str .= $icon;
 		}
 		return $icons_str;
+	}
+
+	/**
+	 * @param \WC_Order $order
+	 * @param int $amount
+	 * @param int $customer_id
+	 *
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function process_standard_payment($order, $amount, $customer_id)
+	{
+		$order_id = PayplugWoocommerceHelper::is_pre_30() ? $order->id : $order->get_id();
+		try {
+			if (!$this->checkBancontact()) {
+				throw new \Exception(__('Payment processing failed. Please retry.', 'payplug'));
+			}
+
+			$address_data = PayplugAddressData::from_order($order);
+			$payment_data = [
+				'amount'           => $amount,
+				'currency'         => get_woocommerce_currency(),
+				'payment_method'   => $this->id,
+				'billing'          => $address_data->get_billing(),
+				'shipping'         => $address_data->get_shipping(),
+				'hosted_payment'   => [
+					'return_url' => esc_url_raw($order->get_checkout_order_received_url()),
+					'cancel_url' => esc_url_raw($order->get_cancel_order_url_raw()),
+				],
+				'notification_url' => esc_url_raw(WC()->api_request_url('PayplugGateway')),
+				'metadata'         => [
+					'order_id'    => $order_id,
+					'customer_id' => ((int) $customer_id > 0) ? $customer_id : 'guest',
+					'domain'      => $this->limit_length(esc_url_raw(home_url()), 500),
+				],
+				"save_card"=> false,
+     			"force_3ds"=> false
+			];
+
+			/**
+			 * Filter the payment data before it's used
+			 *
+			 * @param array $payment_data
+			 * @param int $order_id
+			 * @param array $customer_details
+			 * @param PayplugAddressData $address_data
+			 */
+			$payment_data = apply_filters('payplug_gateway_payment_data', $payment_data, $order_id, [], $address_data);
+			$payment      = $this->api->payment_create($payment_data);
+
+			// Save transaction id for the order
+			PayplugWoocommerceHelper::is_pre_30()
+				? update_post_meta($order_id, '_transaction_id', $payment->id)
+				: $order->set_transaction_id($payment->id);
+
+			if (is_callable([$order, 'save'])) {
+				$order->save();
+			}
+
+			/**
+			 * Fires once a payment has been created.
+			 *
+			 * @param int $order_id Order ID
+			 * @param PaymentResource $payment Payment resource
+			 */
+			\do_action('payplug_gateway_payment_created', $order_id, $payment);
+
+			$metadata = PayplugWoocommerceHelper::extract_transaction_metadata($payment);
+			PayplugWoocommerceHelper::save_transaction_metadata($order, $metadata);
+
+			PayplugGateway::log(sprintf('Payment creation complete for order #%s', $order_id));
+
+			return [
+				'result'   => 'success',
+				'redirect' => $payment->hosted_payment->payment_url,
+				'cancel'   => $payment->hosted_payment->cancel_url,
+			];
+
+		} catch (HttpException $e) {
+			PayplugGateway::log(sprintf('Error while processing order #%s : %s', $order_id, wc_print_r($e->getErrorObject(), true)), 'error');
+			throw new \Exception(__('Payment processing failed. Please retry.', 'payplug'));
+		} catch (\Exception $e) {
+			PayplugGateway::log(sprintf('Error while processing order #%s : %s', $order_id, $e->getMessage()), 'error');
+			throw new \Exception(__('Payment processing failed. Please retry.', 'payplug'));
+		}
+
 	}
 
 }

--- a/src/Controller/Bancontact.php
+++ b/src/Controller/Bancontact.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Payplug\PayplugWoocommerce\Controller;
+
+use Payplug\PayplugWoocommerce\Gateway\PayplugGatewayRequirements;
+use Payplug\PayplugWoocommerce\Gateway\PayplugPermissions;
+use Payplug\PayplugWoocommerce\PayplugWoocommerceHelper;
+use Payplug\PayplugWoocommerce\Gateway\PayplugGateway;
+
+class Bancontact extends PayplugGateway
+{
+
+	public function __construct()
+	{
+
+		parent::__construct();
+
+		/** @var \WC_Settings_API  override $id */
+		$this->id                 = 'bancontact';
+
+		/** @var \WC_Payment_Gateway overwrite for bancontact settings  */
+		$this->method_title       = __('payplug_bancontact_title', 'payplug');
+		$this->method_description = __('payplug_bancontact_description', 'payplug');
+
+		$this->title = __('payplug_bancontact_title', 'payplug');
+		$this->description = __('payplug_bancontact_description', 'payplug');
+
+		if(!$this->checkBancontact())
+			$this->enabled = 'no';
+
+	}
+
+	private function checkBancontact(){
+		$account = PayplugWoocommerceHelper::get_account_data_from_options();
+
+		if (isset($account['payment_methods']['bancontact']['enabled'])) {
+			return  $account['payment_methods']['bancontact']['enabled'];
+		}
+		return true;
+	}
+
+	/**
+	 * Get payment icons.
+	 *
+	 * @return string
+	 */
+	public function get_icon()
+	{
+		$available_img = 'lg-bancontact-checkout.png';
+		$icons = apply_filters('payplug_payment_icons', [
+			'payplug' => sprintf('<img src="%s" alt="Oney 4x" class="payplug-payment-icon" />', esc_url(PAYPLUG_GATEWAY_PLUGIN_URL . '/assets/images/' . $available_img)),
+		]);
+		$icons_str = '';
+		foreach ($icons as $icon) {
+			$icons_str .= $icon;
+		}
+		return $icons_str;
+	}
+
+}


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

