### PR TITLE
Return url fail safe

### DIFF
--- a/src/Controller/Bancontact.php
+++ b/src/Controller/Bancontact.php
@@ -42,7 +42,7 @@ class Bancontact extends PayplugGateway
 				return  $account['payment_methods']['bancontact']['enabled'];
 
 		}
-		
+
 		return false;
 	}
 
@@ -82,6 +82,13 @@ class Bancontact extends PayplugGateway
 			}
 
 			$address_data = PayplugAddressData::from_order($order);
+
+			$return_url = esc_url_raw($order->get_checkout_order_received_url());
+
+			if (!(str_starts_with($return_url, "http"))) {
+				$return_url = get_site_url().$return_url;
+			}
+
 			$payment_data = [
 				'amount'           => $amount,
 				'currency'         => get_woocommerce_currency(),
@@ -89,7 +96,7 @@ class Bancontact extends PayplugGateway
 				'billing'          => $address_data->get_billing(),
 				'shipping'         => $address_data->get_shipping(),
 				'hosted_payment'   => [
-					'return_url' => esc_url_raw($order->get_checkout_order_received_url()),
+					'return_url' => $return_url,
 					'cancel_url' => esc_url_raw($order->get_cancel_order_url_raw()),
 				],
 				'notification_url' => esc_url_raw(WC()->api_request_url('PayplugGateway')),

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -972,6 +972,12 @@ class PayplugGateway extends WC_Payment_Gateway_CC
         try {
             $address_data = PayplugAddressData::from_order($order);
 
+			$return_url = esc_url_raw($order->get_checkout_order_received_url());
+
+			if (!(str_starts_with($return_url, "http"))) {
+				$return_url = get_site_url().$return_url;
+			}
+
             $payment_data = [
                 'amount'           => $amount,
                 'currency'         => get_woocommerce_currency(),
@@ -979,7 +985,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
                 'billing'          => $address_data->get_billing(),
                 'shipping'         => $address_data->get_shipping(),
                 'hosted_payment'   => [
-                    'return_url' => esc_url_raw($order->get_checkout_order_received_url()),
+                    'return_url' => $return_url,
                     'cancel_url' => esc_url_raw($order->get_cancel_order_url_raw()),
                 ],
                 'notification_url' => esc_url_raw(WC()->api_request_url('PayplugGateway')),
@@ -1059,6 +1065,12 @@ class PayplugGateway extends WC_Payment_Gateway_CC
         try {
             $address_data = PayplugAddressData::from_order($order);
 
+			$return_url = esc_url_raw($order->get_checkout_order_received_url());
+
+			if (!(str_starts_with($return_url, "http"))) {
+				$return_url = get_site_url().$return_url;
+			}
+
             $payment_data = [
                 'amount'           => $amount,
                 'currency'         => get_woocommerce_currency(),
@@ -1068,7 +1080,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
                 'shipping'         => $address_data->get_shipping(),
                 'initiator'        => 'PAYER',
                 'hosted_payment'   => [
-                    'return_url' => esc_url_raw($order->get_checkout_order_received_url()),
+                    'return_url' => $return_url,
                     'cancel_url' => esc_url_raw($order->get_cancel_order_url_raw()),
                 ],
                 'notification_url' => esc_url_raw(WC()->api_request_url('PayplugGateway')),

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -225,6 +225,12 @@ HTML;
 
             $address_data = PayplugAddressData::from_order($order);
 
+	        $return_url = esc_url_raw($order->get_checkout_order_received_url());
+
+	        if (!(str_starts_with($return_url, "http"))) {
+		        $return_url = get_site_url().$return_url;
+	        }
+
             $cart_items = [];
             $items = $order->get_items();
             foreach($items as $item) {
@@ -255,7 +261,7 @@ HTML;
                 ],
                 'notification_url' => esc_url_raw(WC()->api_request_url('PayplugGateway')),
                 'hosted_payment'   => [
-                    'return_url' => esc_url_raw($order->get_checkout_order_received_url()),
+                    'return_url' => $return_url,
                     'cancel_url' => esc_url_raw($order->get_cancel_order_url_raw()),
                 ],
                 'metadata'         => [


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

