### PR TITLE
WOOC-369 Fix woocommerce_package_builder dependency for bin/build-plu…

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Check out repository code ${{ github.workflow }}
         uses: actions/checkout@v3
       - name: Start the zip generation
-        run: ./bin/build-plugin-zip.sh
+        run: ./bin/build-plugin-zip.sh qa
       - uses: actions/upload-artifact@v3
         with:
           name: payplug-woocommerce.zip

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -46,15 +46,20 @@ git clean -xdf
 # Run the build
 status "Installing dependencies..."
 composer install --prefer-dist --no-dev -o
-
-# Remove any existing zip file
-rm -f payplug-woocommerce.zip
+if [ -z "$1" ]
+  then
+    npm install
+    status "Generating build..."
+    npm run build:css
+fi
 
 # Remove any existing zip file
 rm -f payplug-woocommerce.zip
 
 # Set the api-qa endpoint
-sed -i 's/api.payplug.com/api-qa.payplug.com/g' 'vendor/payplug/payplug-php/lib/Payplug/Core/APIRoutes.php'
+if [ "$1" = "qa" ]; then
+	sed -i 's/api.payplug.com/api-qa.payplug.com/g' 'vendor/payplug/payplug-php/lib/Payplug/Core/APIRoutes.php'
+fi
 
 # Generate the plugin zip file
 status "Creating archive..."


### PR DESCRIPTION
…gin-zip.sh

- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

