### PR TITLE
Qa 1.9.1

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -7,8 +7,8 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.9.0
- * WC tested up to: 6.7.0
+ * Version:         1.9.1
+ * WC tested up to: 6.8.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.9.0' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.9.1' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,11 @@ PayPlug offers several plans to suit your needs and business requirements. **No 
 2. Display on a WordPress website
 
 == Changelog ==
+= 1.9.1 =
+* IPN minor fix
+* Tested up to Woocommerce 6.8.0
+* Tested up to Wordpress 6.0.1
+
 = 1.9.0 =
 * Apple Pay (beta)
 * Tested up to Woocommerce 6.7.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: PayPlug
 Tags: payplug, woocommerce, gateway, payment, credit card, carte de crédit, carte bancaire, paiement, one click, paiement en ligne, oney
 Requires at least: 4.4
-Tested up to: 6.0
+Tested up to: 6.8
 Requires PHP: 5.6
-Stable tag: 1.9.0
+Stable tag: 1.9.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -245,6 +245,12 @@ class PayplugGateway extends WC_Payment_Gateway_CC
             return;
         }
 
+		//FIXME:: this is being runned 1 time for each gateway,
+		// this comparisson is only needed to only run the process_method one time
+		if($payment_method != $this->id){
+			return;
+		}
+
         $this->response->process_payment($payment);
     }
 

--- a/src/Gateway/PayplugResponse.php
+++ b/src/Gateway/PayplugResponse.php
@@ -43,10 +43,7 @@ class PayplugResponse {
 		$gateway_id = $order->get_payment_method();
 		$metadata = PayplugWoocommerceHelper::extract_transaction_metadata($resource);
 
-		// Remove duplicate Logs
-		if( $gateway_id != $this->gateway->id) {
-			return;
-		}
+		PayplugGateway::log( $this->gateway->id, "error");
 
 		// Ignore undefined orders
 		if (!$order) {


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

