### PR TITLE
develop to qa

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.9.2
+ * Version:         1.9.3
  * WC tested up to: 6.8.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.9.2' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.9.3' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/payplug.php
+++ b/payplug.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.payplug.com/
  * Text Domain:     payplug
  * Domain Path:     /languages
- * Version:         1.9.1
+ * Version:         1.9.2
  * WC tested up to: 6.8.0
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-define( 'PAYPLUG_GATEWAY_VERSION', '1.9.1' );
+define( 'PAYPLUG_GATEWAY_VERSION', '1.9.2' );
 define( 'PAYPLUG_GATEWAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PAYPLUG_GATEWAY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,11 @@ PayPlug offers several plans to suit your needs and business requirements. **No 
 2. Display on a WordPress website
 
 == Changelog ==
+= 1.9.3 =
+* Minor fixes for full support php7
+* Tested up to Woocommerce 6.8.0
+* Tested up to Wordpress 6.0.1
+
 = 1.9.2 =
 * WP version updates
 * Tested up to Woocommerce 6.8.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payplug, woocommerce, gateway, payment, credit card, carte de crédit, car
 Requires at least: 4.4
 Tested up to: 6.0.1
 Requires PHP: 5.6
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payplug, woocommerce, gateway, payment, credit card, carte de crédit, car
 Requires at least: 4.4
 Tested up to: 6.0.1
 Requires PHP: 5.6
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -80,6 +80,11 @@ PayPlug offers several plans to suit your needs and business requirements. **No 
 2. Display on a WordPress website
 
 == Changelog ==
+= 1.9.2 =
+* WP version updates
+* Tested up to Woocommerce 6.8.0
+* Tested up to Wordpress 6.0.1
+
 = 1.9.1 =
 * IPN minor fix
 * Tested up to Woocommerce 6.8.0

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -201,7 +201,7 @@ class ApplePay extends PayplugGateway
 
 			$return_url = esc_url_raw($order->get_checkout_order_received_url());
 
-			if (!(str_starts_with($return_url, "http"))) {
+			if (!(substr( $return_url, 0, 4 ) === "http")) {
 				$return_url = get_site_url().$return_url;
 			}
 

--- a/src/Controller/Bancontact.php
+++ b/src/Controller/Bancontact.php
@@ -85,7 +85,7 @@ class Bancontact extends PayplugGateway
 
 			$return_url = esc_url_raw($order->get_checkout_order_received_url());
 
-			if (!(str_starts_with($return_url, "http"))) {
+			if (!(substr( $return_url, 0, 4 ) === "http")) {
 				$return_url = get_site_url().$return_url;
 			}
 

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -995,7 +995,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
 
 			$return_url = esc_url_raw($order->get_checkout_order_received_url());
 
-			if (!(str_starts_with($return_url, "http"))) {
+			if (!(substr( $return_url, 0, 4 ) === "http")) {
 				$return_url = get_site_url().$return_url;
 			}
 
@@ -1088,7 +1088,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
 
 			$return_url = esc_url_raw($order->get_checkout_order_received_url());
 
-			if (!(str_starts_with($return_url, "http"))) {
+			if (!(substr( $return_url, 0, 4 ) === "http")) {
 				$return_url = get_site_url().$return_url;
 			}
 

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -227,7 +227,7 @@ HTML;
 
 	        $return_url = esc_url_raw($order->get_checkout_order_received_url());
 
-	        if (!(str_starts_with($return_url, "http"))) {
+			if (!(substr( $return_url, 0, 4 ) === "http")) {
 		        $return_url = get_site_url().$return_url;
 	        }
 

--- a/src/Gateway/PayplugResponse.php
+++ b/src/Gateway/PayplugResponse.php
@@ -82,7 +82,7 @@ class PayplugResponse {
 		// but not for Payplug credit card gateway (in this case we check the payment_method from the order itself not the $resource)
 		if (isset($resource->payment_method) && is_array($resource->payment_method)) {
 			$gateway_id = $resource->payment_method['type'];
-			if (str_starts_with($gateway_id, 'oney_')) {
+			if (substr( $gateway_id, 0, 5 ) === "oney_") {
 				$this->oney_ipn($resource);
 			}
 			if($gateway_id == "bancontact") {


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

