### PR TITLE
Amex unauthorized alert

### DIFF
--- a/assets/js/payplug-admin-amex.js
+++ b/assets/js/payplug-admin-amex.js
@@ -13,9 +13,7 @@
 
 		},
 		check_american_express_permissions: (callback) => {
-			$("#amex_test_mode_description").hide();
-			$("#amex_live_mode_description").hide();
-			$("#amex_unauthorized_description").hide();
+
 			payplug_admin.xhr = $
 				.post(
 					payplug_admin_config.ajax_url,
@@ -26,16 +24,15 @@
 				).done((res) => { callback(res) });
 		},
 		check_american_express: (event)=> {
-			payplug_admin.disable_american_express();
 
 			if(payplug_admin.isTestMode()){
 				payplug_admin.uncheck_american_express();
 				payplug_admin.disable_american_express();
 				$("#amex_test_mode_description").show();
 				$("#amex_live_mode_description").hide();
-				$("#amex_unauthorized_description").hide();
 				return;
 			} else {
+				payplug_admin.enable_american_express();
 				$("#amex_test_mode_description").hide();
 				$("#amex_live_mode_description").show();
 			}
@@ -49,9 +46,6 @@
 
 				if(false === res.data){
 					payplug_admin.uncheck_american_express();
-					payplug_admin.disable_american_express();
-					$("#amex_live_mode_description").hide();
-					$("#amex_unauthorized_description").show();
 					return;
 				}
 
@@ -69,7 +63,6 @@
 			jQuery("#woocommerce_payplug_american_express").prop("disabled", true);
 		},
 		enable_american_express: function(){
-			$("#amex_live_mode_description").show();
 			jQuery("#woocommerce_payplug_american_express").prop("disabled", false);
 		}
 	}

--- a/src/Controller/AmericanExpress.php
+++ b/src/Controller/AmericanExpress.php
@@ -54,7 +54,7 @@ class AmericanExpress extends PayplugGateway
 	 */
 	public function process_admin_options() {
 		$data = $this->get_post_data();
-		if ($this->get_post_data()['woocommerce_payplug_mode'] === '0') {
+		if ($data['woocommerce_payplug_mode'] === '0') {
 			$options = get_option('woocommerce_payplug_settings', []);
 			$options['american_express'] = 'no';
 			update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
@@ -62,6 +62,9 @@ class AmericanExpress extends PayplugGateway
 
 		if (isset($data['woocommerce_payplug_american_express'])) {
 			if (($data['woocommerce_payplug_american_express'] == 1) && (!$this->checkAmericanExpress())) {
+				$options = get_option('woocommerce_payplug_settings', []);
+				$options['american_express'] = 'no';
+				update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
 				add_action( 'woocommerce_settings_saved', [$this ,"display_notice"] );
 			}
 		}

--- a/src/Gateway/PayplugGateway.php
+++ b/src/Gateway/PayplugGateway.php
@@ -313,10 +313,6 @@ class PayplugGateway extends WC_Payment_Gateway_CC
 		$domain_bancontact = __( 'payplug_bancontact_activation_url', 'payplug' );
 		$bancontact_call_to_action = sprintf(  ' <a id="bancontact_call_to_action" href="https://%s" target="_blank">%s</a>', $domain_bancontact, $anchor_bancontact );
 
-		$anchor_amex = esc_html_x( __("payplug_amex_activation_request", 'payplug'), 'modal', 'payplug' );
-		$domain_amex = __( 'payplug_amex_activation_url', 'payplug' );
-		$amex_call_to_action = sprintf(  ' <a id="amex_call_to_action" href="https://%s" target="_blank">%s</a>', $domain_amex, $anchor_amex );
-
         $fields = [
             'enabled'                 => [
                 'title'       => __('Enable/Disable', 'payplug'),
@@ -437,8 +433,7 @@ class PayplugGateway extends WC_Payment_Gateway_CC
 				'title'       => __('payplug_amex_title', 'payplug'),
 				'type'        => 'checkbox',
 				'label'       => __('payplug_amex_activate', 'payplug'),
-				'description' => '<p class="description" id="amex_unauthorized_description"> '. __('payplug_amex_unauthorized_description', 'payplug'). $amex_call_to_action .' </p>' .
-								 '<p class="description" id="amex_test_mode_description"> '. __('payplug_amex_testmode_description', 'payplug') .' </p>' .
+				'description' => '<p class="description" id="amex_test_mode_description"> '. __('payplug_amex_testmode_description', 'payplug') .' </p>' .
 								 '<p class="description" id="amex_live_mode_description"> '. __('payplug_amex_livemode_description', 'payplug') .' </p>' ,
 				'default'     => 'no',
 			],


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

