### PR TITLE
Alert messages display fix

### DIFF
--- a/assets/js/payplug-admin-bancontact.js
+++ b/assets/js/payplug-admin-bancontact.js
@@ -30,6 +30,8 @@
 				$("#bancontact_call_to_action").hide();
 				$("#bancontact_live_mode_description_disabled").hide();
 				return;
+			} else {
+				payplug_admin.enableBancontact();
 			}
 			$("#bancontact_test_mode_description").hide();
 			$("#bancontact_call_to_action").show();

--- a/src/Controller/AmericanExpress.php
+++ b/src/Controller/AmericanExpress.php
@@ -65,7 +65,7 @@ class AmericanExpress extends PayplugGateway
 				$options = get_option('woocommerce_payplug_settings', []);
 				$options['american_express'] = 'no';
 				update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
-				add_action( 'woocommerce_settings_saved', [$this ,"display_notice"] );
+				add_action( 'admin_notices', [$this ,"display_notice"] );
 			}
 		}
 

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -54,7 +54,7 @@ class ApplePay extends PayplugGateway
 
 		if (isset($data['woocommerce_payplug_apple_pay'])) {
 			if (($data['woocommerce_payplug_apple_pay'] == 1) && (!$this->checkApplePay())) {
-				add_action( 'woocommerce_settings_saved', [$this ,"display_notice"] );
+				add_action( 'admin_notices', [$this ,"display_notice"] );
 			}
 		}
 

--- a/src/Controller/Bancontact.php
+++ b/src/Controller/Bancontact.php
@@ -174,7 +174,7 @@ class Bancontact extends PayplugGateway
 				$options = get_option('woocommerce_payplug_settings', []);
 				$options['bancontact'] = 'no';
 				update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
-				add_action( 'woocommerce_settings_saved', [$this ,"display_notice"] );
+				add_action( 'admin_notices', [$this ,"display_notice"] );
 			}
 		}
 


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

