### PR TITLE
Fix after login error

### DIFF
--- a/src/Controller/AmericanExpress.php
+++ b/src/Controller/AmericanExpress.php
@@ -54,10 +54,12 @@ class AmericanExpress extends PayplugGateway
 	 */
 	public function process_admin_options() {
 		$data = $this->get_post_data();
-		if ($data['woocommerce_payplug_mode'] === '0') {
-			$options = get_option('woocommerce_payplug_settings', []);
-			$options['american_express'] = 'no';
-			update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
+		if (isset($data['woocommerce_payplug_mode'])) {
+			if ($data['woocommerce_payplug_mode'] === '0') {
+				$options = get_option('woocommerce_payplug_settings', []);
+				$options['american_express'] = 'no';
+				update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
+			}
 		}
 
 		if (isset($data['woocommerce_payplug_american_express'])) {

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -45,13 +45,13 @@ class ApplePay extends PayplugGateway
 	 */
 	public function process_admin_options() {
 		$data = $this->get_post_data();
-
-		if ($this->get_post_data()['woocommerce_payplug_mode'] === '0') {
-			$options = get_option('woocommerce_payplug_settings', []);
-			$options['apple_pay'] = 'no';
-			update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
+		if (isset($data['woocommerce_payplug_mode'])) {
+			if ( $this->get_post_data()['woocommerce_payplug_mode'] === '0' ) {
+				$options              = get_option( 'woocommerce_payplug_settings', [] );
+				$options['apple_pay'] = 'no';
+				update_option( 'woocommerce_payplug_settings', apply_filters( 'woocommerce_settings_api_sanitized_fields_payplug', $options ) );
+			}
 		}
-
 		if (isset($data['woocommerce_payplug_apple_pay'])) {
 			if (($data['woocommerce_payplug_apple_pay'] == 1) && (!$this->checkApplePay())) {
 				add_action( 'admin_notices', [$this ,"display_notice"] );

--- a/src/Controller/Bancontact.php
+++ b/src/Controller/Bancontact.php
@@ -163,10 +163,12 @@ class Bancontact extends PayplugGateway
 	 */
 	public function process_admin_options() {
 		$data = $this->get_post_data();
-		if ($data['woocommerce_payplug_mode'] === '0') {
-			$options = get_option('woocommerce_payplug_settings', []);
-			$options['bancontact'] = 'no';
-			update_option( 'woocommerce_payplug_settings', apply_filters('woocommerce_settings_api_sanitized_fields_payplug', $options) );
+		if (isset($data['woocommerce_payplug_mode'])) {
+			if ( $data['woocommerce_payplug_mode'] === '0' ) {
+				$options               = get_option( 'woocommerce_payplug_settings', [] );
+				$options['bancontact'] = 'no';
+				update_option( 'woocommerce_payplug_settings', apply_filters( 'woocommerce_settings_api_sanitized_fields_payplug', $options ) );
+			}
 		}
 
 		if (isset($data['woocommerce_payplug_bancontact'])) {


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

