### PR TITLE
Ajax login and get permissions

### DIFF
--- a/src/Admin/Ajax.php
+++ b/src/Admin/Ajax.php
@@ -207,13 +207,12 @@ class Ajax {
 
 	public function payplug_login() {
 
-		$email = $_POST['payplug_email'];
-		$password = $_POST['payplug_password'];
+		$email = sanitize_email($_POST['payplug_email']);
+		$password = wp_unslash($_POST['payplug_password']);
 
 		try {
 			$response = Authentication::getPermissionsByLogin($email, $password);
 			if (empty($response) || !isset($response)) {
-				var_dump($response);
 				return wp_send_json_error($response);
 			}
 

--- a/src/Admin/Ajax.php
+++ b/src/Admin/Ajax.php
@@ -3,6 +3,7 @@
 namespace Payplug\PayplugWoocommerce\Admin;
 
 // Exit if accessed directly
+use Payplug\Exception\HttpException;
 use Payplug\Payplug;
 use Payplug\Authentication;
 use Payplug\PayplugWoocommerce\Gateway\PayplugGateway;
@@ -30,12 +31,14 @@ class Ajax {
 	const CHECK_LIVE_PERMISSIONS = 'check_live_permissions';
 	const CHECK_BANCONTACT_PERMISSIONS = 'check_bancontact_permissions';
 	const CHECK_APPLEPAY_PERMISSIONS = 'check_applepay_permissions';
+	const PAYPLUG_LOGIN = 'payplug_login';
 
 	public function __construct() {
 		add_action( 'wp_ajax_' . self::REFRESH_KEY_ACTION, [ $this, 'handle_refresh_keys' ] );
 		add_action( 'wp_ajax_' . self::CHECK_LIVE_PERMISSIONS, [ $this, 'check_live_permissions' ] );
 		add_action( 'wp_ajax_' . self::CHECK_BANCONTACT_PERMISSIONS, [ $this, 'check_bancontact_permissions' ] );
 		add_action( 'wp_ajax_' . self::CHECK_APPLEPAY_PERMISSIONS, [ $this, 'check_applepay_permissions' ] );
+		add_action( 'wp_ajax_' . self::PAYPLUG_LOGIN, [ $this, 'payplug_login' ] );
 	}
 
 	public function handle_refresh_keys() {
@@ -192,5 +195,31 @@ class Ajax {
 			),
 			'yes'
 		);
+	}
+
+
+	/**
+	 *
+	 * Ajax paypal login
+	 *
+	 * @return JSON
+	 */
+
+	public function payplug_login() {
+
+		$email = $_POST['payplug_email'];
+		$password = $_POST['payplug_password'];
+
+		try {
+			$response = Authentication::getPermissionsByLogin($email, $password);
+			if (empty($response) || !isset($response)) {
+				var_dump($response);
+				return wp_send_json_error($response);
+			}
+
+			return wp_send_json_success($response);
+		} catch (HttpException $e) {
+			return wp_send_json_error($e->getErrorObject());
+		}
 	}
 }


### PR DESCRIPTION
- [x] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [x] Generate payplug_woocommerce.zip
- [x] Install payplug_woocommerce.zip on your Woocommerce environment
- [x] Login to your newly installed PayPlug plugin
- [x] Validate a simple payment with PayPlug
- [x] Validate a refund partial/total with PayPlug
- [x] Check apache logs

