### PR TITLE
SMP-780 : Fix ssl check Apple pay

### DIFF
--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -122,8 +122,12 @@ class ApplePay extends PayplugGateway
 	 */
 	public function isSSL()
 	{
-		if( !empty( $_SERVER['https'] ) )
+		if( !empty( $_SERVER['HTTPS'] ) ) {
+			if ( 'on' == strtolower($_SERVER['HTTPS']) )
+				return true;
+		} elseif ( isset($_SERVER['SERVER_PORT']) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
 			return true;
+		}
 
 		if( !empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' )
 			return true;


### PR DESCRIPTION
- [ ] Bump PayPlug version with a 4th digit (ex: 1.1.0 -> 1.1.0.1)
- [ ] Generate payplug_woocommerce.zip
- [ ] Install payplug_woocommerce.zip on your Woocommerce environment
- [ ] Login to your newly installed PayPlug plugin
- [ ] Validate a simple payment with PayPlug
- [ ] Validate a refund partial/total with PayPlug
- [ ] Check apache logs

