### PR TITLE
Adds a new hook in the payment process for third parties

### DIFF
--- a/src/Gateway/PayplugResponse.php
+++ b/src/Gateway/PayplugResponse.php
@@ -50,6 +50,9 @@ class PayplugResponse {
 			return;
 		}
 
+		// Third party hook
+		\do_action('payplug_gateway_payment_response_third', $order_id, $resource, $is_payment_with_token, $source);
+
 		/**
 		 *
 		 * Checking if it is coming from the order confirmation page or the IPN


### PR DESCRIPTION
Hello, thank you for the plugin which is well developed.
However, there is a serious lack of hook in another place.

In my particular case, I had to develop my system to be able to use the _Authorization_ type payment method.

I encountered a problem with the change of order status which is not "known" to the extension.

By adding a "custom" hook we allow the third party to be able to interact with the IPN and respond to particular cases.

Thank you for your validation