### PR TITLE
PRE-2919 fix: Remove CartesBancaires from Apple Pay supported network

### DIFF
--- a/assets/js/payplug-apple-pay-cart.js
+++ b/assets/js/payplug-apple-pay-cart.js
@@ -116,7 +116,6 @@
 					"supports3DS"
 				],
 				"supportedNetworks": [
-					"cartesBancaires",
 					"visa",
 					"masterCard"
 				],

--- a/assets/js/payplug-apple-pay.js
+++ b/assets/js/payplug-apple-pay.js
@@ -64,7 +64,6 @@
 					"supports3DS"
 				],
 				"supportedNetworks": [
-					"cartesBancaires",
 					"visa",
 					"masterCard"
 				],

--- a/resources/js/frontend/wc-payplug-apple_pay-blocks.js
+++ b/resources/js/frontend/wc-payplug-apple_pay-blocks.js
@@ -113,7 +113,6 @@ const Content = (props) => {
 					"supports3DS"
 				],
 				"supportedNetworks": [
-					"cartesBancaires",
 					"visa",
 					"masterCard"
 				],

--- a/resources/js/frontend/wc-payplug-apple_pay_cart-blocks.js
+++ b/resources/js/frontend/wc-payplug-apple_pay_cart-blocks.js
@@ -25,7 +25,6 @@ const ApplePayCart = ( props ) =>{
 					"supports3DS"
 				],
 				"supportedNetworks": [
-					"cartesBancaires",
 					"visa",
 					"masterCard"
 				],


### PR DESCRIPTION
Remove CartesBancaires from Apple Pay supported network