### PR TITLE
PRE-3220: Fix infinite recursion in Oney availability check

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,5 +2,5 @@
   "version": "2.17.4",
   "wc_tested_up_to": "10.6.1",
   "wp_tested_up_to": "6.9.4",
-  "changelog": "* Fix: OAuth collision with other plugins\n * Fix: Apple Pay with virtual products"
+  "changelog": "* Fix: OAuth collision with other plugins\n * Fix: Apple Pay with virtual products\n * Fix: Oney infinite loop on cart recalculation"
 }

--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -149,9 +149,25 @@ HTML;
     /**
      * Check if Oney is available
      *
-     * @return false
+     * @return bool|int true, false, or an ONEY_* status code
      */
     public function check_oney_is_available()
+    {
+        static $is_running = false;
+        if ($is_running) {
+            return false;
+        }
+        $is_running = true;
+        try {
+            $result = $this->do_check_oney_is_available();
+        } finally {
+            $is_running = false;
+        }
+
+        return $result;
+    }
+
+    private function do_check_oney_is_available()
     {
         $cart = WC()->cart;
 


### PR DESCRIPTION
## Description
<!-- Provide a clear summary of the changes and the problem it solves. -->
<!-- Include any relevant context or background information. -->

**Motivation:**
Add a static recursion guard to check_oney_is_available() to prevent
re-entrant calls triggered by third-party plugins (e.g. Tyche Softwares)
reinitializing payment gateways during cart fee recalculation.

**Related issue(s):** Closes # [PRE-3220](https://payplug-prod.atlassian.net/browse/PRE-3220)

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [x]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate


[PRE-3220]: https://payplug-prod.atlassian.net/browse/PRE-3220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ