### PR TITLE
PRE-3379: Fix undefined HTTP_HOST warning in Apple Pay during WP-Cron

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,5 +2,5 @@
   "version": "2.17.4",
   "wc_tested_up_to": "10.6.1",
   "wp_tested_up_to": "6.9.4",
-  "changelog": "* Fix: OAuth collision with other plugins\n * Fix: Apple Pay with virtual products\n * Fix: Oney infinite loop on cart recalculation"
+  "changelog": "* Fix: OAuth collision with other plugins\n * Fix: Apple Pay with virtual products\n * Fix: Oney infinite loop on cart recalculation\n * Fix: Apple Pay undefined HTTP_HOST warning in WP-Cron context"
 }

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -43,7 +43,7 @@ class ApplePay extends PayplugGateway
 
         $this->title = __('payplug_apple_pay_title', 'payplug');
         $this->description = '<div id="apple-pay-button-wrapper"><apple-pay-button buttonstyle="black" type="pay" locale="' . get_locale() . '"></apple-pay-button></div>';
-        $this->domain_name = $_SERVER['HTTP_HOST'];
+        $this->domain_name = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : parse_url(home_url(), PHP_URL_HOST);
         $this->enabled = 'no';
 
         if ($this->checkApplePay() && is_admin()) {
@@ -204,7 +204,7 @@ class ApplePay extends PayplugGateway
                 'cart_shipping' => WC()->cart->get_shipping_total(),
                 'countryCode' => WC()->customer->get_billing_country(),
                 'currencyCode' => get_woocommerce_currency(),
-                'apple_pay_domain' => $_SERVER['HTTP_HOST'],
+                'apple_pay_domain' => isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : parse_url(home_url(), PHP_URL_HOST),
             ]
         );
 

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -43,7 +43,7 @@ class ApplePay extends PayplugGateway
 
         $this->title = __('payplug_apple_pay_title', 'payplug');
         $this->description = '<div id="apple-pay-button-wrapper"><apple-pay-button buttonstyle="black" type="pay" locale="' . get_locale() . '"></apple-pay-button></div>';
-        $this->domain_name = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : parse_url(home_url(), PHP_URL_HOST);
+        $this->domain_name = $_SERVER['HTTP_HOST'] ?? (parse_url(home_url(), PHP_URL_HOST) ?: '');
         $this->enabled = 'no';
 
         if ($this->checkApplePay() && is_admin()) {

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -43,7 +43,7 @@ class ApplePay extends PayplugGateway
 
         $this->title = __('payplug_apple_pay_title', 'payplug');
         $this->description = '<div id="apple-pay-button-wrapper"><apple-pay-button buttonstyle="black" type="pay" locale="' . get_locale() . '"></apple-pay-button></div>';
-        $this->domain_name = $_SERVER['HTTP_HOST'] ?? (parse_url(home_url(), PHP_URL_HOST) ?: '');
+        $this->domain_name = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : parse_url(home_url(), PHP_URL_HOST);
         $this->enabled = 'no';
 
         if ($this->checkApplePay() && is_admin()) {
@@ -204,7 +204,7 @@ class ApplePay extends PayplugGateway
                 'cart_shipping' => WC()->cart->get_shipping_total(),
                 'countryCode' => WC()->customer->get_billing_country(),
                 'currencyCode' => get_woocommerce_currency(),
-                'apple_pay_domain' => isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : parse_url(home_url(), PHP_URL_HOST),
+                'apple_pay_domain' => $this->domain_name,
             ]
         );
 


### PR DESCRIPTION
## Description
<!-- Provide a clear summary of the changes and the problem it solves. -->
<!-- Include any relevant context or background information. -->

**Motivation:**
Fix PHP warning Undefined array key "HTTP_HOST" triggered repeatedly during WP-Cron execution. $_SERVER['HTTP_HOST'] is not set in CLI/cron contexts, so we now fall back to parse_url(home_url(), PHP_URL_HOST) which reliably returns the site domain in all execution contexts.

**Related issue(s):** Closes # [PRE-3379](https://payplug-prod.atlassian.net/browse/PRE-3379)

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [x]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate


[PRE-3379]: https://payplug-prod.atlassian.net/browse/PRE-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ