### PR TITLE
PRE-3330: prevent fatal error when shipping method has no eligible ra…

### DIFF
--- a/.github/workflows/wooco-marketplace-publish.yml
+++ b/.github/workflows/wooco-marketplace-publish.yml
@@ -11,6 +11,7 @@ jobs:
   # -----------------------------------------------------------------------
   verify-svn:
     name: Verify SVN connection
+    if: ${{ !contains(github.ref_name, '-rc') }}
     runs-on: ubuntu-latest
     steps:
       - name: Install SVN

--- a/src/Front/ApplePay.php
+++ b/src/Front/ApplePay.php
@@ -47,8 +47,9 @@ class ApplePay
                 }
 
                 $rates = $shipping_method->get_rates_for_package($package);
-                if ($this->checkApplePayShipping($shipping_method)) {
-                    $shipping_rate = $rates[$shipping_method->get_rate_id()];
+				$rate_id = $shipping_method->get_rate_id();
+				if (isset($rates[$rate_id]) && $this->checkApplePayShipping($shipping_method)) {
+					$shipping_rate = $rates[$rate_id];
 
                     array_push($shippings, [
                         'identifier' => $shipping_method->id . '_' . $shipping_method->instance_id,


### PR DESCRIPTION
## Problème

Sur la page panier, le bouton Apple Pay disparaît lorsqu'une méthode de livraison est configurée dans WooCommerce mais **inéligible pour le panier courant** (ex. : Chronopost refusé car le produit est trop lourd).

### Cause

Dans `src/Front/ApplePay.php`, l'appel Ajax `applepay_get_shippings` accède directement à `$rates[$shipping_method->get_rate_id()]` sans vérifier que la clé existe.

Quand `get_rates_for_package()` retourne un tableau vide (méthode inéligible), `$shipping_rate` vaut `null` → appel de `->get_cost()` sur `null` → **fatal error → HTTP 500** → le plugin masque le bouton Apple Pay par sécurité.

## Correction

Ajout d'un `isset()` sur la clé avant d'accéder au rate. Si la méthode est inéligible pour le panier courant, elle est simplement ignorée dans la liste des options de livraison Apple Pay.

```php
// Avant
if ($this->checkApplePayShipping($shipping_method)) {
    $shipping_rate = $rates[$shipping_method->get_rate_id()];

// Après
$rate_id = $shipping_method->get_rate_id();
if ($this->checkApplePayShipping($shipping_method) && isset($rates[$rate_id])) {
    $shipping_rate = $rates[$rate_id];
```

## Impact

- Aucun changement de comportement pour les méthodes éligibles
- Les méthodes inéligibles sont silencieusement exclues au lieu de provoquer un crash
- Le bouton Apple Pay reste affiché correctement