### PR TITLE
PRE-3403: Fix Oney second refund warning

### DIFF
--- a/src/Gateway/PayplugGatewayOney3x.php
+++ b/src/Gateway/PayplugGatewayOney3x.php
@@ -429,15 +429,19 @@ HTML;
      */
     public function oney_refund_text($order)
     {
-        if ($this->id === $order->get_payment_method() && parent::can_refund_order($order) && $order->get_status() !== 'refunded' && $this->api) {
+        if ($this->id === $order->get_payment_method() && parent::can_refund_order($order) && $order->get_status() !== 'refunded' && $this->payplug_api) {
             $order_metadata = $order->get_meta('_payplug_metadata');
 
             if (is_array($order_metadata) && !empty($order_metadata['transaction_id'])) {
-                $payment = $this->payplug_api->payment_retrieve($order_metadata['transaction_id']);
-                $today = current_time('Y-m-d H:i:s');
-                $can_refund_date = date('Y-m-d H:i:s', $payment->__get('refundable_after'));
-                if ($can_refund_date >= $today) {
-                    echo "<p style='color: red;'>" . __('Refund will be possible 48 hours after the last payment or refund transaction.', 'payplug') . '</p>';
+                try {
+                    $payment = $this->payplug_api->payment_retrieve($order_metadata['transaction_id']);
+                    $today = current_time('Y-m-d H:i:s');
+                    $can_refund_date = date('Y-m-d H:i:s', $payment->__get('refundable_after'));
+                    if ($can_refund_date >= $today) {
+                        echo "<p style='color: red;'>" . __('Refund will be possible 48 hours after the last payment or refund transaction.', 'payplug') . '</p>';
+                    }
+                } catch (\Exception $e) {
+                    PayplugGateway::log(sprintf('Could not retrieve refundable_after for Oney order: %s', $e->getMessage()), 'error');
                 }
             }
         }

--- a/src/PayplugWoocommerceHelper.php
+++ b/src/PayplugWoocommerceHelper.php
@@ -394,6 +394,10 @@ class PayplugWoocommerceHelper
      */
     public static function extract_transaction_metadata($resource)
     {
+        // For non-card payment methods (e.g. Oney), the API returns "card": null.
+        // Accessing null->property throws \Error in PHP 8+, which is not caught by catch(\Exception).
+        $card = (isset($resource->card) && $resource->card !== null) ? $resource->card : null;
+
         return [
             'transaction_id' => sanitize_text_field($resource->id),
             'paid' => (bool) $resource->is_paid,
@@ -403,11 +407,11 @@ class PayplugWoocommerceHelper
             '3ds' => (bool) $resource->is_3ds,
             'live' => (bool) $resource->is_live,
             'paid_at' => isset($resource->hosted_payment->paid_at) ? sanitize_text_field($resource->hosted_payment->paid_at) : sanitize_text_field($resource->created_at),
-            'card_last4' => sanitize_text_field($resource->card->last4),
-            'card_exp_month' => sanitize_text_field($resource->card->exp_month),
-            'card_exp_year' => sanitize_text_field($resource->card->exp_year),
-            'card_brand' => sanitize_text_field($resource->card->brand),
-            'card_country' => sanitize_text_field($resource->card->country),
+            'card_last4' => $card !== null ? sanitize_text_field($card->last4) : '',
+            'card_exp_month' => $card !== null ? sanitize_text_field($card->exp_month) : '',
+            'card_exp_year' => $card !== null ? sanitize_text_field($card->exp_year) : '',
+            'card_brand' => $card !== null ? sanitize_text_field($card->brand) : '',
+            'card_country' => $card !== null ? sanitize_text_field($card->country) : '',
         ];
     }
 


### PR DESCRIPTION
## Description
PRE-3403: Fix Oney second refund warning

**Motivation:**

**Related issue(s):** Closes #

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [ ]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate
