### PR TITLE
PRE-3264: Fix all PPRO payment methods display in reorder page

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,5 +2,5 @@
   "version": "3.0.0",
   "wc_tested_up_to": "10.6.1",
   "wp_tested_up_to": "6.9.4",
-  "changelog": "* UPGRADE: Upgrading module with minimal PHP 7.4 version\n* Fix: Fix order not available on admin order page"
+  "changelog": "* UPGRADE: Upgrading module with minimal PHP 7.4 version\n* Fix: Fix order not available on admin order page\n* Fix: Fix display of all PPRO payment methods on reorder page"
 }

--- a/src/Controller/PayplugGenericGateway.php
+++ b/src/Controller/PayplugGenericGateway.php
@@ -85,8 +85,9 @@ class PayplugGenericGateway extends PayplugGateway implements PayplugGatewayBuil
             return false;
         }
 
-        if (!is_admin() && !PayplugWoocommerceHelper::is_checkout_block()) {
-            if (empty(WC()->cart) && !is_admin()) {
+        $is_order_pay = is_wc_endpoint_url('order-pay');
+        if (!is_admin() && (!PayplugWoocommerceHelper::is_checkout_block() || $is_order_pay)) {
+            if (empty(WC()->cart) && !is_admin() && !$is_order_pay) {
                 return false;
             }
 
@@ -96,6 +97,9 @@ class PayplugGenericGateway extends PayplugGateway implements PayplugGatewayBuil
                 $items = $order->get_items();
                 $country_code_shipping = $order->get_shipping_country();
                 $country_code_billing = $order->get_billing_country();
+                if (is_null(WC()->cart)) {
+                    wc_load_cart();
+                }
                 $this->order_items_to_cart(WC()->cart, $items);
             }
 


### PR DESCRIPTION
## Description
PRE-3264: Fix all PPRO payment methods display in reorder page

**Motivation:**

**Related issue(s):** Closes #

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [ ]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate
