### PR TITLE
PRE-3266: Fix disappearance of the Apple Pay payment method from the cart page

### DIFF
--- a/assets/js/payplug-apple-pay-cart.js
+++ b/assets/js/payplug-apple-pay-cart.js
@@ -11,17 +11,19 @@
 				return;
 			}
 
-			apple_pay.updateOrderTotal();
+			apple_pay.updateOrderTotal(true);
 			$('apple-pay-button').on('click', apple_pay.ProcessCheckout)
 		},
-		updateOrderTotal: function(){
+		updateOrderTotal: function(fetchShippings){
 			jQuery.post(
 				apple_pay_params.ajax_url_applepay_get_order_totals
 
 			).done(function(results){
 				if(results.success){
 					apple_pay_params.total = results.data;
-					apple_pay.getShippings();
+					if(fetchShippings){
+						apple_pay.getShippings();
+					}
 				} else {
 					$apple_pay_button.remove();
 				}
@@ -239,7 +241,7 @@
 				}
 			}).done(function (response) {
 				apple_pay.showError(response.data.message, "info");
-				apple_pay.updateOrderTotal();
+				apple_pay.updateOrderTotal(true);
 			})
 		},
 		showError: function (message="", type = "info") {
@@ -264,7 +266,7 @@
 	apple_pay.init();
 
 	jQuery( 'body' ).on( 'updated_cart_totals', function() {
-		apple_pay.updateOrderTotal();
+		apple_pay.updateOrderTotal(false);
 		jQuery('apple-pay-button').off('click', apple_pay.ProcessCheckout).on('click', apple_pay.ProcessCheckout);
 	})
 

--- a/release.json
+++ b/release.json
@@ -2,5 +2,5 @@
   "version": "3.0.0",
   "wc_tested_up_to": "10.6.1",
   "wp_tested_up_to": "6.9.4",
-  "changelog": "* UPGRADE: Upgrading module with minimal PHP 7.4 version\n* Fix: Fix order not available on admin order page\n* Fix: Fix display of all PPRO payment methods on reorder page\n* Fix: Fix multiple calls on same request using Apple Pay\n* Feat: Display clear message when attempting to log in legacy with a multi-company account"
+  "changelog": "* UPGRADE: Upgrading module with minimal PHP 7.4 version\n* Fix: Fix order not available on admin order page\n* Fix: Fix display of all PPRO payment methods on reorder page\n* Fix: Fix multiple calls on same request using Apple Pay\n* Feat: Display clear message when attempting to log in legacy with a multi-company account\n* Fix: Disappearance of the Apple Pay payment method from the cart page"
 }

--- a/src/Controller/ApplePay.php
+++ b/src/Controller/ApplePay.php
@@ -276,8 +276,11 @@ class ApplePay extends PayplugGateway
             if (!empty($available_rates)) {
                 foreach ($available_rates as $method) {
                     if (in_array($method->get_method_id(), $apple_carriers)) {
-                        if ($chosen_method === $method->get_method_id() . ':' . $method->get_instance_id()) {
-                            $allowed = true;
+                        // On cart page, show the button if any eligible carrier is available —
+                        // the actual shipping selection happens inside the Apple Pay modal.
+                        // On checkout, restrict to the currently chosen shipping method.
+                        if (is_cart() || $chosen_method === $method->get_method_id() . ':' . $method->get_instance_id()) {
+                            return true;
                         }
                     }
                 }


### PR DESCRIPTION
## Description
PRE-3266: Fix disappearance of the Apple Pay payment method from the cart page

**Motivation:**

**Related issue(s):** Closes #

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [x]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate
