### PR TITLE
PRE-3400: Fix payment method CB remains active on the checkout even a…

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,5 +2,5 @@
   "version": "3.0.0",
   "wc_tested_up_to": "10.6.1",
   "wp_tested_up_to": "6.9.4",
-  "changelog": "* UPGRADE: Upgrading module with minimal PHP 7.4 version\n* Fix: Fix order not available on admin order page\n* Fix: Fix display of all PPRO payment methods on reorder page\n* Fix: Fix multiple calls on same request using Apple Pay\n* Feat: Display clear message when attempting to log in legacy with a multi-company account\n* Fix: Disappearance of the Apple Pay payment method from the cart page\n* Fix: Fix product duplication at the time of payment during a WC Subscription renewal"
+  "changelog": "* UPGRADE: Upgrading module with minimal PHP 7.4 version\n* Fix: Fix order not available on admin order page\n* Fix: Fix display of all PPRO payment methods on reorder page\n* Fix: Fix multiple calls on same request using Apple Pay\n* Feat: Display clear message when attempting to log in legacy with a multi-company account\n* Fix: Disappearance of the Apple Pay payment method from the cart page\n* Fix: Fix product duplication at the time of payment during a WC Subscription renewal\n* Fix: Fix payment method CB remains active on the checkout even after disabling the PayPlug module"
 }

--- a/src/Gateway/PayplugCreditCard.php
+++ b/src/Gateway/PayplugCreditCard.php
@@ -76,11 +76,11 @@ class PayplugCreditCard extends PayplugGateway
      */
     private function handle_cc_enabled()
     {
-        if (!empty($this->settings['enabled']) && $this->settings['enabled']) {
-            $enabled = !empty($this->settings[$this->id]) ? $this->settings[$this->id] : $this->settings['enabled'];
-            $this->enabled = $enabled ? 'yes' : 'no';
+        if (!empty($this->settings['enabled']) && (bool) $this->settings['enabled']) {
+            $active = $this->get_configuration()->get_option('payment_methods.configuration.payplug.active');
+            $this->enabled = ($active === null || (bool) $active) ? 'yes' : 'no';
         } else {
-            $this->enabled = 'yes';
+            $this->enabled = 'no';
         }
 
         return $this->enabled;

--- a/tests/phpunit/src/Gateway/PayplugCreditCard_test.php
+++ b/tests/phpunit/src/Gateway/PayplugCreditCard_test.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Payplug\PayplugWoocommerce\Tests\phpunit\src\Gateway;
+
+use Payplug\PayplugWoocommerce\Gateway\PayplugCreditCard;
+use PHPUnit\Framework\TestCase;
+
+class PayplugCreditCard_test extends TestCase
+{
+    private array $base_settings = [
+        'enabled' => true,
+        'mode' => false,
+        'payment_methods' => [
+            'configuration' => [
+                'payplug' => [
+                    'active' => true,
+                    'title' => 'Credit card checkout',
+                    'description' => '',
+                    'save_card' => false,
+                    'embedded_mode' => 'redirect',
+                ],
+            ],
+        ],
+    ];
+
+    protected function tearDown(): void
+    {
+        delete_option('woocommerce_payplug_settings');
+        parent::tearDown();
+    }
+
+    public function test_gateway_enabled_when_module_enabled_as_boolean(): void
+    {
+        // AccountGateway::register() persists 'enabled' => true (bool), not 'yes'
+        update_option('woocommerce_payplug_settings', $this->base_settings);
+        $gateway = new PayplugCreditCard();
+        self::assertSame('yes', $gateway->enabled);
+    }
+
+    public function test_gateway_enabled_when_module_enabled_as_string_yes(): void
+    {
+        $settings = $this->base_settings;
+        $settings['enabled'] = 'yes';
+        update_option('woocommerce_payplug_settings', $settings);
+        $gateway = new PayplugCreditCard();
+        self::assertSame('yes', $gateway->enabled);
+    }
+
+    public function test_gateway_disabled_when_cb_method_inactive(): void
+    {
+        $settings = $this->base_settings;
+        $settings['payment_methods']['configuration']['payplug']['active'] = false;
+        update_option('woocommerce_payplug_settings', $settings);
+        $gateway = new PayplugCreditCard();
+        self::assertSame('no', $gateway->enabled);
+    }
+
+    public function test_gateway_disabled_when_module_disabled(): void
+    {
+        $settings = $this->base_settings;
+        $settings['enabled'] = false;
+        update_option('woocommerce_payplug_settings', $settings);
+        $gateway = new PayplugCreditCard();
+        self::assertSame('no', $gateway->enabled);
+    }
+
+    public function test_gateway_enabled_on_legacy_config_without_active_key(): void
+    {
+        // Legacy config pre-migration: 'payment_methods' key absent → null fallback → enabled
+        $settings = $this->base_settings;
+        unset($settings['payment_methods']);
+        update_option('woocommerce_payplug_settings', $settings);
+        $gateway = new PayplugCreditCard();
+        self::assertSame('yes', $gateway->enabled);
+    }
+}


### PR DESCRIPTION
…fter disabling the PayPlug module

## Description
PRE-3400: Fix payment method CB remains active on the checkout even after disabling the PayPlug module

**Motivation:**

**Related issue(s):** Closes #

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [x]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate
